### PR TITLE
Feature/tower compatibility

### DIFF
--- a/botoweb/db/converter.py
+++ b/botoweb/db/converter.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2013 Chris Moyer http://coredumped.org/
+# Copyright (c) 2014 Saikat DebRoy
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the
@@ -14,7 +15,7 @@
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
 # ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
@@ -22,7 +23,7 @@ import boto.sdb
 from botoweb.db.key import Key
 from botoweb.db.coremodel import Model
 from botoweb.db.blob import Blob
-from botoweb.db.property import ListProperty, MapProperty
+from botoweb.db.property import ListProperty, MapProperty, JSON, JSONProperty
 from datetime import datetime, date, time
 from botoweb.exceptions import TimeDecodeError
 from botoweb import ISO8601
@@ -54,6 +55,7 @@ class Converter(object):
 						time : (self.encode_time, self.decode_time),
 						Blob: (self.encode_blob, self.decode_blob),
 						str: (self.encode_string, self.decode_string),
+						JSON: (self.encode_json_item, self.decode_json_item),
 					}
 
 	def encode(self, item_type, value):
@@ -106,11 +108,25 @@ class Converter(object):
 				new_value.append('%s:%s' % (urllib.quote(key), encoded_value))
 		return new_value
 
+	def encode_json(self, prop, value):
+		if value is None:
+			return None
+		if isinstance(value, JSON):
+			value = value.value
+		if isinstance(value, dict):
+			return self.encode_map(prop, value)
+		elif isinstance(value, list):
+			return self.encode_list(prop, value)
+		else:
+			return self.encode_json_item(value)
+
 	def encode_prop(self, prop, value):
 		if isinstance(prop, ListProperty):
 			return self.encode_list(prop, value)
 		elif isinstance(prop, MapProperty):
 			return self.encode_map(prop, value)
+		elif isinstance(prop, JSONProperty):
+			return self.encode_json(prop, value)
 		else:
 			return self.encode(prop.data_type, value)
 
@@ -154,13 +170,62 @@ class Converter(object):
 			value = self.decode(item_type, value)
 		return (key, value)
 
+	def decode_json(self, prop, value):
+		if isinstance(value, (set, list)):
+			if not value:
+				return value
+			value = self.decode_map(prop, value)
+			if all(isinstance(k, (int, long)) for k in value):
+				if min(value.iterkeys()) == 0 and max(value.iterkeys()) == len(value) - 1:
+					# The keys are all distinct, the minimum is 0 and max is len(value) - 1
+					# So, keys == range(0, len(value)) and so, value must be a list
+					value = [value[k] for k in xrange(len(value))]
+		else:
+			value = self.decode_json_item(value)
+		return value
+
 	def decode_prop(self, prop, value):
 		if isinstance(prop, ListProperty):
 			return self.decode_list(prop, value)
 		elif isinstance(prop, MapProperty):
 			return self.decode_map(prop, value)
+		elif isinstance(prop, JSONProperty):
+			return self.decode_json(prop, value)
 		else:
 			return self.decode(prop.data_type, value)
+
+	def encode_json_item(self, value):
+		if value is None:
+			return None
+		if isinstance(value, JSON):
+			value = value.value
+		if isinstance(value, int):
+			return self.encode_int(value)
+		elif isinstance(value, long):
+			return self.encode_long(value)
+		elif isinstance(value, basestring):
+			return self.encode_string(value)
+		else:
+			import json
+
+			return json.dumps(value)
+
+	def decode_json_item(self, value):
+		if isinstance(value, basestring):
+			import json
+
+			try:
+				parsed_value = json.loads(value)
+			except ValueError:
+				value = self.decode_string(value)
+			else:
+				if isinstance(parsed_value, int):
+					value = self.decode_int(value)
+				elif isinstance(parsed_value, long):
+					value = self.decode_long(value)
+				else:
+					value = parsed_value
+		return value
 
 	def encode_int(self, value):
 		value = int(value)
@@ -362,4 +427,3 @@ class StringConverter(Converter):
 		if isinstance(value, str) or isinstance(value, unicode):
 			return value
 		return value.isoformat()
-

--- a/botoweb/db/coremodel.py
+++ b/botoweb/db/coremodel.py
@@ -20,7 +20,7 @@
 # IN THE SOFTWARE.
 
 from botoweb.db.manager import get_manager
-from botoweb.db.property import Property
+from botoweb.db.property import Property, JSON
 from botoweb.db.key import Key
 from botoweb.db.query import Query
 from decimal import Decimal
@@ -344,6 +344,8 @@ class Model(object):
 						else:
 							rv[k] = str(val[k])
 				val = rv
+			elif isinstance(val, JSON):
+				val = val.value
 			else:
 				# Fall back to encoding as a string
 				try:

--- a/botoweb/db/coremodel.py
+++ b/botoweb/db/coremodel.py
@@ -410,11 +410,6 @@ class Model(object):
 			if not isinstance(val, list) and not isinstance(val, set):
 				val = [val]
 			val = [cls._decode(prop.item_type, v, prop) for v in val]
-		elif isinstance(t, tuple):
-			# Support for JSON multi-types
-			import json
-			if(val):
-				val = json.loads(val)
 		elif t not in (str, unicode, int):
 			val = t(val)
 		return val

--- a/botoweb/db/property.py
+++ b/botoweb/db/property.py
@@ -748,6 +748,38 @@ class MapProperty(Property):
 		return {}
 
 
+class JSON(object):
+	def __init__(self, value):
+		if isinstance(value, JSON):
+			self.value = value.value
+		else:
+			self.set(value)
+
+	def set(self, value):
+		import json
+		try:
+			json.dumps(value)
+		except Exception as e:
+			raise ValueError('%s in %s JSONProperty' % (str(e), self.name))
+		self.value = value
+
+	def __eq__(self, other):
+		return self.value == other.value
+
+	def __ne__(self, other):
+		return self.value != other.value
+
+	def __str__(self):
+		return str(self.value)
+
+	def __unicode__(self):
+		return unicode(self.value)
+
+	def __len__(self):
+		# Note: this fails if self.value is a number
+		return len(self.value)
+
+
 class JSONProperty(Property):
 
 	data_type = (dict, list, str, unicode, int, long, float, type(None))

--- a/botoweb/db/property.py
+++ b/botoweb/db/property.py
@@ -783,6 +783,7 @@ class JSON(object):
 class JSONProperty(Property):
 
 	data_type = JSON
+	item_type = JSON
 	type_name = 'JSON'
 
 	def __init__(self, verbose_name=None, name=None, default=None, required=False,


### PR DESCRIPTION
Here are the promised changes with a JSON data type holding JSON compatible values. Compatibility is tested by doing a json.dumps(value) in the JSON.set(value) method: I am not sure we can do something more efficient. However, the value set is the one originally given. So, a JSON object will hold a list or a dict or an int or a string as the python object, not their JSON representation.
